### PR TITLE
solve Logger.cpp:105:19Error in fprintf(), add format argument %s

### DIFF
--- a/utility/Logger.cpp
+++ b/utility/Logger.cpp
@@ -102,7 +102,7 @@ void Logger::log(Level level, const char* file, int line, const char* format, va
     memset(buf, 0, sizeof(buf));
     strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S  ", ptm);
     flockfile(m_fp);
-    fprintf(m_fp, buf);
+    fprintf(m_fp, "%s", buf); 
     fprintf(m_fp, "%s  ", s_level[level]);
     fprintf(m_fp, "%s:%d  ", file, line);
     vfprintf(m_fp, format, arg_ptr);


### PR DESCRIPTION
### Logger.cpp Error in 105 line about fprintf() function
add  "%s" argument in fprintf function parameter list